### PR TITLE
little typo in kubectl command

### DIFF
--- a/cks-challenges/trivy/step1.md
+++ b/cks-challenges/trivy/step1.md
@@ -15,6 +15,6 @@
    `kubectl get nodes -o wide`{{execute}}
 
    Deploy sample apps:
-   `kubectl -f ./deployments`{{execute}}  
+   `kubectl apply -f ./deployments`{{execute}}  
 
 


### PR DESCRIPTION
I got the following error while doing the scenario
```shell
Error: unknown command "kubectl" for "kubectl"
Run 'kubectl --help' for usage.
unknown command "kubectl" for "kubectl"
```